### PR TITLE
Fix DB init and update main

### DIFF
--- a/config/database.py
+++ b/config/database.py
@@ -9,9 +9,10 @@ from sqlalchemy import (
     ForeignKey,
 )
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import sessionmaker, relationship, scoped_session
 from datetime import datetime
 from .settings import settings
+import os
 
 engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -24,4 +25,14 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def init_db():
+    try:
+        engine = create_engine(os.getenv("DATABASE_URL"))
+        global Session
+        Session = scoped_session(sessionmaker(bind=engine))
+        print("✅ Database initialized")
+    except Exception as e:
+        print(f"❌ Database error: {str(e)}")
    

--- a/main.py
+++ b/main.py
@@ -27,9 +27,6 @@ class DianaBot:
         if not self.token:
             raise ValueError("TELEGRAM_BOT_TOKEN no encontrado en variables de entorno")
 
-        # Inicializar base de datos
-        init_db()
-
         # Crear aplicación
         self.application = Application.builder().token(self.token).build()
 
@@ -90,7 +87,12 @@ class DianaBot:
         )
 
 
-if __name__ == "__main__":
+def main():
+    init_db()
     bot = DianaBot()
     bot.run()
+
+
+if __name__ == "__main__":
+    main()
    


### PR DESCRIPTION
## Summary
- add `init_db` helper in `config/database.py`
- use `init_db` in the new `main()` function and adjust bot initialization

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: ImportError cannot import name 'MissionDifficulty')*

------
https://chatgpt.com/codex/tasks/task_e_686481c0c6d8832994b1bd984bab8b47