### PR TITLE
Add shop and narrative models

### DIFF
--- a/models/narrative.py
+++ b/models/narrative.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from config.database import Base
+
+
+class LorePiece(Base):
+    __tablename__ = 'lore_pieces'
+    id = Column(Integer, primary_key=True)
+    title = Column(String(100))
+
+
+class UserLorePiece(Base):
+    __tablename__ = 'user_lore_pieces'
+    user_id = Column(Integer, ForeignKey('users.id'), primary_key=True)
+    lore_piece_id = Column(Integer, ForeignKey('lore_pieces.id'), primary_key=True)

--- a/models/shop.py
+++ b/models/shop.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from sqlalchemy import Column, Integer, String, Enum as SQLEnum, ForeignKey
+from config.database import Base
+
+
+class ShopItemType(Enum):
+    SKIN = "skin"
+    POWERUP = "powerup"
+
+
+class ShopRarity(Enum):
+    COMMON = "common"
+    EPIC = "epic"
+
+
+class ShopItem(Base):
+    __tablename__ = "shop_items"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50), nullable=False)
+    item_type = Column(SQLEnum(ShopItemType))
+    rarity = Column(SQLEnum(ShopRarity))


### PR DESCRIPTION
## Summary
- add missing `ShopItem` model with enums for item type and rarity
- add basic narrative models `LorePiece` and `UserLorePiece`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services')*
- `PYTHONPATH=. pytest -q` *(fails: cannot import name 'MissionDifficulty' from models.mission)*

------
https://chatgpt.com/codex/tasks/task_e_686482b09e248329aad2ab853786d072