### PR TITLE
Fix user service method name across project

### DIFF
--- a/handlers/user.py
+++ b/handlers/user.py
@@ -17,7 +17,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
 
     # Registrar o actualizar usuario
-    db_user = user_service.get_or_create_user(
+    db_user = user_service.create_or_update_user(
         telegram_id=user.id,
         username=user.username,
         first_name=user.first_name,

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -24,7 +24,7 @@ class UserService:
 
     # ===== GESTIÓN DE USUARIOS =====
 
-    def get_or_create_user(
+    def create_or_update_user(
         self,
         telegram_id: int,
         first_name: str,

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -26,7 +26,7 @@ def user_required(func: Callable) -> Callable:
             return
 
         # Obtener o crear usuario
-        db_user = user_service.get_or_create_user(
+        db_user = user_service.create_or_update_user(
             telegram_id=telegram_user.id,
             username=telegram_user.username,
             first_name=telegram_user.first_name,


### PR DESCRIPTION
## Summary
- rename `get_or_create_user` to `create_or_update_user`
- update user decorator and legacy user handler

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q` *(fails: ImportError cannot import name 'MissionDifficulty')*

------
https://chatgpt.com/codex/tasks/task_e_68648452ccc48329a6afb16b7a43c2c3