### PR TITLE
Add placeholder models and DB init scaffolding

### DIFF
--- a/config/database.py
+++ b/config/database.py
@@ -24,4 +24,9 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def init_db():
+    # Lógica mínima de inicialización
+    print("Base de datos inicializada (placeholder)")
    

--- a/models/auction.py
+++ b/models/auction.py
@@ -39,6 +39,10 @@ class ItemType(enum.Enum):
     CUSTOM_ITEM = "custom_item"
 
 
+class AuctionItemType(enum.Enum):
+    VIDEO = "video"
+
+
 class Auction(Base):
     __tablename__ = "auctions"
 

--- a/models/channel.py
+++ b/models/channel.py
@@ -10,7 +10,7 @@ from sqlalchemy import (
     Enum as SQLEnum,
 )
 from sqlalchemy.orm import relationship
-from database import Base
+from config.database import Base
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Dict, Any

--- a/models/game.py
+++ b/models/game.py
@@ -21,12 +21,38 @@ class GameType(enum.Enum):
     WORD_GAME = "word_game"
     MEMORY = "memory"
     MATH = "math"
+    RIDDLE = "riddle"
+    WORD_ASSOCIATION = "word_association"
+    PATTERN_RECOGNITION = "pattern_recognition"
+    MORAL_DILEMMA = "moral_dilemma"
+    QUICK_CHOICE = "quick_choice"
+    MEMORY_CHALLENGE = "memory_challenge"
+    CREATIVITY_TEST = "creativity_test"
 
 
 class DifficultyLevel(enum.Enum):
     EASY = "easy"
     MEDIUM = "medium"
     HARD = "hard"
+
+
+class GameDifficulty(enum.Enum):
+    EASY = "easy"
+    MEDIUM = "medium"
+    HARD = "hard"
+    EXPERT = "expert"
+
+
+class GameStatus(enum.Enum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class Game(Base):
+    __tablename__ = "games"
+
+    id = Column(Integer, primary_key=True, index=True)
 
 
 class TriviaQuestion(Base):

--- a/models/mission.py
+++ b/models/mission.py
@@ -21,6 +21,19 @@ class MissionType(enum.Enum):
     NARRATIVE = "narrative"
 
 
+class MissionDifficulty(enum.Enum):
+    EASY = "easy"
+    MEDIUM = "medium"
+    HARD = "hard"
+
+
+class MissionStatus(enum.Enum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    PAUSED = "paused"
+
+
 class Mission(Base):
     __tablename__ = "missions"
 

--- a/models/narrative.py
+++ b/models/narrative.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+from config.database import Base
+
+
+class LorePiece(Base):
+    __tablename__ = "lore_pieces"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+
+class UserLorePiece(Base):
+    __tablename__ = "user_lore_pieces"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    lore_piece_id = Column(Integer, ForeignKey("lore_pieces.id"))
+
+    user = relationship("User", back_populates="lore_pieces")
+    lore_piece = relationship("LorePiece")
+
+
+class NarrativeProgress(Base):
+    __tablename__ = "narrative_progress"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+
+
+class LoreCombination(Base):
+    __tablename__ = "lore_combinations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    piece_a_id = Column(Integer, ForeignKey("lore_pieces.id"))
+    piece_b_id = Column(Integer, ForeignKey("lore_pieces.id"))
+    result_piece_id = Column(Integer, ForeignKey("lore_pieces.id"))

--- a/models/shop.py
+++ b/models/shop.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Enum, DateTime, Boolean
+from sqlalchemy.orm import relationship
+from config.database import Base
+import enum
+from datetime import datetime
+
+
+class ShopItemType(enum.Enum):
+    GENERIC = "generic"
+
+
+class ShopRarity(enum.Enum):
+    COMMON = "common"
+
+
+class ShopCategory(Base):
+    __tablename__ = "shop_categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100))
+
+
+class ShopItem(Base):
+    __tablename__ = "shop_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    category_id = Column(Integer, ForeignKey("shop_categories.id"))
+    name = Column(String(100))
+    price = Column(Integer, default=0)
+    item_type = Column(Enum(ShopItemType))
+    rarity = Column(Enum(ShopRarity))
+    is_active = Column(Boolean, default=True)
+
+    category = relationship("ShopCategory")
+
+
+class ShopPurchase(Base):
+    __tablename__ = "shop_purchases"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    item_id = Column(Integer, ForeignKey("shop_items.id"))
+    purchased_at = Column(DateTime, default=datetime.utcnow)
+
+    item = relationship("ShopItem")

--- a/models/user.py
+++ b/models/user.py
@@ -1,5 +1,8 @@
-from sqlalchemy import Column, Integer, String, DateTime, Boolean, Text
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, Text, ForeignKey
 from sqlalchemy.orm import relationship
+from models.narrative import UserLorePiece
+from models.narrative_state import UserNarrativeState
+from models.auction import AuctionBid
 from datetime import datetime
 from config.database import Base
 
@@ -32,6 +35,7 @@ class User(Base):
     missions = relationship("UserMission", back_populates="user")
     lore_pieces = relationship("UserLorePiece", back_populates="user")
     auction_bids = relationship("AuctionBid", back_populates="user")
+    narrative_state = relationship("UserNarrativeState", uselist=False, back_populates="user")
 
 
 class UserStats(Base):

--- a/services/game_service.py
+++ b/services/game_service.py
@@ -17,7 +17,7 @@ class GameService:
     def __init__(self):
         self.db = next(get_db())
         self.lucien = LucienVoice()
-        
+
         # Configuración de juegos
         self.GAME_CONFIGS = self._load_game_configurations()
         
@@ -39,6 +39,10 @@ class GameService:
             GameType.MEMORY_CHALLENGE: ['focused', 'persistent'],
             GameType.CREATIVITY_TEST: ['imaginative', 'artistic']
         }
+
+    def _load_game_configurations(self) -> Dict[str, Any]:
+        """Carga configuración de juegos (placeholder)"""
+        return {}
     
     # ===== GESTIÓN DE SESIONES DE JUEGO =====
     
@@ -470,5 +474,4 @@ class GameService:
             GameDifficulty.EXPERT: 10
         }
 
-Perfecto adelante
    

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -22,6 +22,15 @@ class UserService:
         self.db = next(get_db())
         self.lucien = LucienVoice()
 
+    def create_or_update_user(self, user_data: Dict[str, Any]):
+        """Compatibilidad con tests - crea o actualiza un usuario"""
+        return self.get_or_create_user(
+            user_data.get("telegram_id"),
+            user_data.get("first_name"),
+            user_data.get("username"),
+            user_data.get("last_name"),
+        )
+
     # ===== GESTIÓN DE USUARIOS =====
 
     def get_or_create_user(


### PR DESCRIPTION
## Summary
- create basic placeholders for narrative and shop models
- implement a minimal `init_db` for startup
- update models and services to import the new classes
- add small fixes for imports and mappings

## Testing
- `python main.py` *(fails: httpx.ProxyError due to network)*
- `PYTHONPATH=. pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686488dd544883298650a9474f8fb69f