### PR TITLE
Implement placeholder service methods

### DIFF
--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -120,6 +120,12 @@ class MissionService:
 
         return created_missions
 
+    def generate_personalized_missions(self, user_id: int) -> List[Dict[str, Any]]:
+        """Genera misiones personalizadas para el usuario (dummy)."""
+
+        # Placeholder: Devuelve lista vacía
+        return []
+
     def check_mission_completion(
         self, mission_id: int, user_action: Dict[str, Any] = None
     ) -> Dict[str, Any]:

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -543,6 +543,18 @@ class UserService:
 
         return leaderboard
 
+    def get_user_detailed_stats(self, user_id: int) -> Dict[str, Any]:
+        """Devuelve estadísticas detalladas del usuario (dummy)."""
+
+        # Placeholder: datos simulados
+        return {"level": 1, "xp": 100, "missions_completed": 5}
+
+    def get_user_stats(self, user_id: int) -> Dict[str, Any]:
+        """Devuelve estadísticas básicas del usuario (dummy)."""
+
+        # Placeholder
+        return {"health": 100, "energy": 50}
+
     # ===== MÉTODOS AUXILIARES =====
 
     def _calculate_level_from_experience(self, experience: int) -> int:


### PR DESCRIPTION
## Summary
- add basic get_user_detailed_stats and get_user_stats placeholders
- stub generate_personalized_missions in MissionService

## Testing
- `python - <<'PY'
from services.user_service import UserService
print(UserService().get_user_detailed_stats(1))
PY` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services')*

------
https://chatgpt.com/codex/tasks/task_e_6864916b0c088329b767de2a145f28a1