### PR TITLE
Implement Fase 1.2 models

### DIFF
--- a/models/narrative.py
+++ b/models/narrative.py
@@ -1,6 +1,10 @@
 from sqlalchemy import Column, Integer, ForeignKey
 from sqlalchemy.orm import relationship
-from config.database import Base
+from sqlalchemy.ext.declarative import declarative_base
+from config.database import Base as DBBase
+
+Base = declarative_base()
+Base = DBBase
 
 
 class LorePiece(Base):

--- a/models/shop.py
+++ b/models/shop.py
@@ -1,15 +1,24 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, Enum, DateTime, Boolean
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    ForeignKey,
+    Enum as SQLEnum,
+    DateTime,
+    Boolean,
+)
 from sqlalchemy.orm import relationship
 from config.database import Base
-import enum
+from enum import Enum
 from datetime import datetime
 
 
-class ShopItemType(enum.Enum):
+class ShopItemType(Enum):
     GENERIC = "generic"
+    SKIN = "skin"
 
 
-class ShopRarity(enum.Enum):
+class ShopRarity(Enum):
     COMMON = "common"
 
 
@@ -27,8 +36,8 @@ class ShopItem(Base):
     category_id = Column(Integer, ForeignKey("shop_categories.id"))
     name = Column(String(100))
     price = Column(Integer, default=0)
-    item_type = Column(Enum(ShopItemType))
-    rarity = Column(Enum(ShopRarity))
+    item_type = Column(SQLEnum(ShopItemType))
+    rarity = Column(SQLEnum(ShopRarity))
     is_active = Column(Boolean, default=True)
 
     category = relationship("ShopCategory")


### PR DESCRIPTION
## Summary
- expand `ShopItemType` to include `SKIN`
- switch `ShopItemType` and `ShopRarity` to use Python enums
- use SQLAlchemy Enum alias in `ShopItem`
- prepare narrative models with a declarative base placeholder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686499eb4dd88329b5666e22208f871c