### PR TITLE
Rename AuctionItemType to ItemType

### DIFF
--- a/models/auction.py
+++ b/models/auction.py
@@ -30,7 +30,7 @@ class AuctionType(enum.Enum):
     RESERVE = "reserve"  # Con precio de reserva
 
 
-class ItemType(enum.Enum):
+class AuctionItemCategory(enum.Enum):
     VIP_ACCESS = "vip_access"
     CUSTOM_ROLE = "custom_role"
     EXCLUSIVE_CONTENT = "exclusive_content"
@@ -39,7 +39,7 @@ class ItemType(enum.Enum):
     CUSTOM_ITEM = "custom_item"
 
 
-class AuctionItemType(enum.Enum):
+class ItemType(enum.Enum):
     VIDEO = "video"
 
 
@@ -101,7 +101,7 @@ class AuctionItem(Base):
     id = Column(Integer, primary_key=True, index=True)
     auction_id = Column(Integer, ForeignKey("auctions.id"), nullable=False)
 
-    item_type = Column(Enum(ItemType), nullable=False)
+    item_type = Column(Enum(AuctionItemCategory), nullable=False)
     name = Column(String(200), nullable=False)
     description = Column(Text)
     quantity = Column(Integer, default=1)

--- a/services/auction_service.py
+++ b/services/auction_service.py
@@ -5,7 +5,7 @@ from models.auction import (
     AuctionItem,
     AuctionBid,
     AuctionStatus,
-    AuctionItemType,
+    ItemType,
 )
 from models.user import User
 from models.narrative_state import UserNarrativeState, NarrativeLevel
@@ -947,7 +947,7 @@ El contenido exclusivo ha sido entregado a tu colección privada.
                 special_content = {
                     "title": "Bienvenida Premium de Diana",
                     "description": "Diana ha preparado algo especial para celebrar tu primera compra premium...",
-                    "type": AuctionItemType.VIDEO,
+                    "type": ItemType.VIDEO,
                     "rarity_level": "epic",
                 }
 


### PR DESCRIPTION
## Summary
- rename `AuctionItemType` enum to `ItemType` in auction models
- rename original `ItemType` to `AuctionItemCategory`
- update service imports and uses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649fa63898832999d3d967bdaca0e8