### PR TITLE
Fix foreign keys in channel models

### DIFF
--- a/models/channel.py
+++ b/models/channel.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     JSON,
     BigInteger,
     Enum as SQLEnum,
+    ForeignKey,
 )
 from sqlalchemy.orm import relationship
 from config.database import Base
@@ -90,7 +91,10 @@ class Channel(Base):
 
     # Relaciones
     memberships = relationship(
-        "ChannelMembership", back_populates="channel", cascade="all, delete-orphan"
+        "ChannelMembership",
+        back_populates="channel",
+        cascade="all, delete-orphan",
+        foreign_keys="[ChannelMembership.channel_id]",
     )
     access_tokens = relationship(
         "ChannelAccessToken", back_populates="channel", cascade="all, delete-orphan"
@@ -101,7 +105,7 @@ class ChannelMembership(Base):
     __tablename__ = "channel_memberships"
 
     id = Column(Integer, primary_key=True, index=True)
-    channel_id = Column(Integer, nullable=False, index=True)
+    channel_id = Column(Integer, ForeignKey('channels.id'), nullable=False, index=True)
     user_id = Column(Integer, nullable=False, index=True)
     telegram_user_id = Column(BigInteger, nullable=False, index=True)
 
@@ -138,7 +142,7 @@ class ChannelAccessToken(Base):
     __tablename__ = "channel_access_tokens"
 
     id = Column(Integer, primary_key=True, index=True)
-    channel_id = Column(Integer, nullable=False, index=True)
+    channel_id = Column(Integer, ForeignKey('channels.id'), nullable=False, index=True)
     token = Column(String(100), unique=True, index=True)
 
     # Configuración del token


### PR DESCRIPTION
## Summary
- define `ForeignKey` on `channel_id` fields for `ChannelMembership` and `ChannelAccessToken`
- use explicit `foreign_keys` option on `Channel.memberships`

## Testing
- `pytest -q`
- `python - <<'PY'
from models.channel import Channel, ChannelMembership
channel = Channel()
membership = ChannelMembership(channel=channel)
print('channel.id:', channel.id)
print('membership.channel_id:', membership.channel_id)
print('Equal:', membership.channel_id == channel.id)
PY`
- `alembic revision --autogenerate -m "fix_foreign_keys"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a8dded3c83299030e705214dde03