### PR TITLE
Implement gamification features

### DIFF
--- a/handlers/gamification.py
+++ b/handlers/gamification.py
@@ -1,0 +1,69 @@
+from aiogram import Router, types, F
+from aiogram.fsm.context import FSMContext
+
+from services.mission_service import MissionService
+from services.gamification_service import GamificationService
+from keyboards.inline import mission_accept_kb, minigame_kb
+from states.user_states import Gamification
+from utils.decorators import onboarding_required
+
+router = Router()
+mission_service = MissionService()
+gamification_service = GamificationService()
+
+
+@router.message(commands=["misiones", "mision"])
+@onboarding_required
+async def show_daily_mission(message: types.Message, state: FSMContext, user):
+    user_mission = await mission_service.assign_daily_mission(user.id)
+    if user_mission is None:
+        await message.answer("No hay misiones disponibles por ahora.")
+        return
+    mission = await mission_service.get_mission_details(user_mission.mission_id)
+    await message.answer(
+        f"🎯 {mission.title}\n{mission.description}",
+        reply_markup=mission_accept_kb(user_mission.id).as_markup(),
+    )
+    await state.update_data(mission_id=user_mission.id)
+    await state.set_state(Gamification.selecting_mission)
+
+
+@router.callback_query(Gamification.selecting_mission, F.data.startswith("accept_mission:"))
+async def accept_mission(callback: types.CallbackQuery, state: FSMContext):
+    await callback.answer()
+    await callback.message.answer(
+        "Has aceptado la misión. Prepárate para perder el tiempo.",
+        reply_markup=minigame_kb().as_markup(),
+    )
+    await state.set_state(Gamification.playing_minigame)
+
+
+@router.callback_query(Gamification.playing_minigame, F.data == "play_minigame")
+async def play_minigame(callback: types.CallbackQuery, state: FSMContext):
+    data = await state.get_data()
+    mission_id = data.get("mission_id")
+    if mission_id:
+        await gamification_service.update_progress(mission_id)
+    await state.clear()
+    await callback.answer()
+    await callback.message.answer(
+        "Minijuego completado. Usa /reclamar para tu magnífica recompensa."
+    )
+
+
+@router.message(commands=["reclamar"])
+@onboarding_required
+async def claim_reward(message: types.Message, user):
+    missions = await gamification_service.get_unclaimed_completed(user.id)
+    if not missions:
+        await message.answer("Nada que reclamar. Sigue intentándolo.")
+        return
+    mission = missions[0]
+    details = await gamification_service.claim_reward(mission.id)
+    if details:
+        await message.answer(
+            f"🎁 Recompensa obtenida: {details.reward_besitos} 💎 Besitos"
+        )
+    else:
+        await message.answer("Algo salió mal al reclamar tu recompensa.")
+

--- a/keyboards/inline.py
+++ b/keyboards/inline.py
@@ -1,0 +1,16 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def mission_accept_kb(mission_id: int) -> InlineKeyboardBuilder:
+    builder = InlineKeyboardBuilder()
+    builder.button(
+        text="Aceptar 🎯 esta gloriosa pérdida de tiempo",
+        callback_data=f"accept_mission:{mission_id}",
+    )
+    return builder
+
+
+def minigame_kb() -> InlineKeyboardBuilder:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Jugar 🎮", callback_data="play_minigame")
+    return builder

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from aiogram import Bot, Dispatcher
 
 from config import settings
 from database_init import init_db
-from handlers import onboarding, backpack, combination, vip_access, notifications
+from handlers import onboarding, backpack, combination, vip_access, notifications, gamification
 from middlewares.vip_middleware import VIPMiddleware
 from middlewares.logging import LoggingMiddleware
 from utils.notification_scheduler import NotificationScheduler
@@ -18,6 +18,7 @@ async def main() -> None:
     dp.include_router(combination.router)
     dp.include_router(vip_access.router)
     dp.include_router(notifications.router)
+    dp.include_router(gamification.router)
     # VIP middleware can be attached to specific channels if needed
     # dp.message.middleware(VIPMiddleware(channel_id=0))
     scheduler = NotificationScheduler(bot)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,6 +2,7 @@ from .core import User
 from .narrative import LorePiece, UserBackpack
 from .vip import VIPAccess, VIPToken
 from .notifications import Notification
+from .gamification import Mission, UserMission, DailyGift
 
 __all__ = [
     "User",
@@ -10,4 +11,7 @@ __all__ = [
     "VIPAccess",
     "VIPToken",
     "Notification",
+    "Mission",
+    "UserMission",
+    "DailyGift",
 ]

--- a/models/gamification.py
+++ b/models/gamification.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+
+from database_init import Base
+
+
+class Mission(Base):
+    __tablename__ = "missions"
+
+    id = Column(Integer, primary_key=True)
+    mission_type = Column(String(50), nullable=False)
+    title = Column(String(100), nullable=False)
+    description = Column(String(255))
+    reward_besitos = Column(Integer, default=0)
+    reward_lore = Column(Integer, default=0)
+
+
+class UserMission(Base):
+    __tablename__ = "user_missions"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    mission_id = Column(Integer, ForeignKey("missions.id"), nullable=False)
+    progress = Column(Integer, default=0)
+    completed = Column(Boolean, default=False)
+    claimed = Column(Boolean, default=False)
+
+    user = relationship("User")
+    mission = relationship("Mission")
+
+
+class DailyGift(Base):
+    __tablename__ = "daily_gifts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    claimed_at = Column(DateTime, default=datetime.utcnow)
+    besitos_reward = Column(Integer, default=0)
+    lore_reward = Column(Integer, default=0)
+
+    user = relationship("User")

--- a/services/gamification_service.py
+++ b/services/gamification_service.py
@@ -1,0 +1,43 @@
+from sqlalchemy import select
+
+from database_init import get_session
+from models.gamification import UserMission, Mission
+
+
+class GamificationService:
+    async def update_progress(self, user_mission_id: int, increment: int = 1) -> UserMission:
+        async for session in get_session():
+            stmt = select(UserMission).where(UserMission.id == user_mission_id)
+            result = await session.execute(stmt)
+            user_mission = result.scalar_one_or_none()
+            if user_mission is None:
+                return None
+            user_mission.progress += increment
+            if user_mission.progress >= 1:
+                user_mission.completed = True
+            await session.commit()
+            await session.refresh(user_mission)
+            return user_mission
+
+    async def claim_reward(self, user_mission_id: int) -> Mission:
+        async for session in get_session():
+            stmt = select(UserMission).where(UserMission.id == user_mission_id)
+            result = await session.execute(stmt)
+            user_mission = result.scalar_one_or_none()
+            if user_mission is None or not user_mission.completed or user_mission.claimed:
+                return None
+            user_mission.claimed = True
+            await session.commit()
+            mission_stmt = select(Mission).where(Mission.id == user_mission.mission_id)
+            mission_res = await session.execute(mission_stmt)
+            return mission_res.scalar_one_or_none()
+
+    async def get_unclaimed_completed(self, user_id: int) -> list[UserMission]:
+        async for session in get_session():
+            stmt = select(UserMission).where(
+                UserMission.user_id == user_id,
+                UserMission.completed == True,
+                UserMission.claimed == False,
+            )
+            result = await session.execute(stmt)
+            return result.scalars().all()

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from random import choice
+from sqlalchemy import select, insert
+
+from database_init import get_session
+from models.gamification import Mission, UserMission
+
+
+class MissionService:
+    async def assign_daily_mission(self, user_id: int) -> UserMission:
+        async for session in get_session():
+            stmt = select(UserMission).join(Mission).where(
+                UserMission.user_id == user_id,
+                Mission.mission_type == "daily",
+                UserMission.completed == False,
+            )
+            result = await session.execute(stmt)
+            existing = result.scalar_one_or_none()
+            if existing:
+                return existing
+
+            mission_stmt = select(Mission).where(Mission.mission_type == "daily")
+            missions = (await session.execute(mission_stmt)).scalars().all()
+            if not missions:
+                return None
+            mission = choice(missions)
+            user_mission = UserMission(user_id=user_id, mission_id=mission.id)
+            session.add(user_mission)
+            await session.commit()
+            await session.refresh(user_mission)
+            return user_mission
+
+    async def get_mission_details(self, mission_id: int) -> Mission:
+        async for session in get_session():
+            stmt = select(Mission).where(Mission.id == mission_id)
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()

--- a/states/user_states.py
+++ b/states/user_states.py
@@ -13,3 +13,8 @@ class CombiningPieces(StatesGroup):
 
 class AwaitingVIPValidation(StatesGroup):
     awaiting_vip_validation = State()
+
+
+class Gamification(StatesGroup):
+    selecting_mission = State()
+    playing_minigame = State()


### PR DESCRIPTION
## Summary
- add gamification models for missions
- expose new models in the package
- add states for mission flow and minigames
- create mission and gamification services
- include gamification handlers and keyboards
- wire gamification router in the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68659b98a0948329a16e90d3785d00af