### PR TITLE
Switch Telegram id fields to BigInteger

### DIFF
--- a/models/core.py
+++ b/models/core.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy import Column, Integer, BigInteger, String, Boolean, DateTime
 
 from database_init import Base
 
@@ -7,7 +7,7 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True)
-    telegram_id = Column(Integer, unique=True, nullable=False)
+    telegram_id = Column(BigInteger, unique=True, nullable=False)
     username = Column(String(64))
     first_name = Column(String(64))
     is_onboarded = Column(Boolean, default=False)

--- a/models/notifications.py
+++ b/models/notifications.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, BigInteger, String, Boolean, ForeignKey, DateTime
 from sqlalchemy.orm import relationship
 
 from database_init import Base
@@ -9,7 +9,7 @@ class Notification(Base):
     __tablename__ = "notifications"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.telegram_id"), nullable=False)
+    user_id = Column(BigInteger, ForeignKey("users.telegram_id"), nullable=False)
     notification_type = Column(String(50))
     message = Column(String(255))
     tone = Column(String(50))

--- a/models/vip.py
+++ b/models/vip.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, BigInteger, String, Boolean, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 
 from database_init import Base
@@ -9,7 +9,7 @@ class VIPAccess(Base):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    channel_id = Column(Integer, nullable=False)
+    channel_id = Column(BigInteger, nullable=False)
     access_granted = Column(DateTime, default=datetime.utcnow)
     access_expires = Column(DateTime)
     is_active = Column(Boolean, default=True)


### PR DESCRIPTION
## Summary
- use SQLAlchemy `BigInteger` for telegram ID columns
- update Notification and VIP models accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68659e7aa914832992523ae78b49bd62