### PR TITLE
Fix unterminated string in start_handler

### DIFF
--- a/handlers/start_handler.py
+++ b/handlers/start_handler.py
@@ -579,4 +579,35 @@ Pocos llegan tan lejos en ganar su confianza...
             return f"""
 *[Con expectativa]*
 
-{first_name}, Diana está
+{first_name}, Diana está claramente interesada en ti. Tus acciones no pasan desapercibidas.
+
+*[Con anticipación]*
+
+Estás muy cerca de algo... especial.
+            """.strip()
+
+        elif trust >= 40:
+            return f"""
+*[Con aprobación]*
+
+{first_name}, Diana ha comenzado a notarte. Tu dedicación está dando frutos.
+
+*[Con aliento]*
+
+Continúa así y pronto verás recompensas más... significativas.
+            """.strip()
+
+        else:
+            return f"""
+*[Con evaluación]*
+
+{first_name}, Diana está observando tus primeros pasos. Cada acción cuenta.
+
+*[Con orientación]*
+
+Demuestra dedicación y consistencia para ganar su atención.
+            """.strip()
+
+
+# Registrar handler
+callback_handler = CallbackQueryHandler(CallbackHandler().handle_callback)


### PR DESCRIPTION
## Summary
- fix unterminated f-string in `handlers/start_handler.py`
- fill missing progress messages for different trust levels

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b2dd02048329a821e581a04d61c1