### PR TITLE
Add navigation callbacks

### DIFF
--- a/handlers/callback_handler.py
+++ b/handlers/callback_handler.py
@@ -39,6 +39,36 @@ class CallbackHandler:
                 await self._handle_premium(update, context)
             elif callback_data.startswith("intro_"):
                 await self._handle_intro_callbacks(update, context, callback_data)
+            elif callback_data == "back_to_menu":
+                await self._handle_back_to_menu(update, context)
+            elif callback_data == "back_to_start":
+                await self._handle_back_to_start(update, context)
+            elif callback_data == "back_to_profile":
+                await self._handle_back_to_profile(update, context)
+            elif callback_data == "back_to_missions":
+                await self._handle_back_to_missions(update, context)
+            elif callback_data == "back_to_premium":
+                await self._handle_back_to_premium(update, context)
+            elif callback_data == "main_menu":
+                await self._handle_main_menu(update, context)
+            elif callback_data == "home":
+                await self._handle_home(update, context)
+            elif callback_data == "cancel":
+                await self._handle_cancel(update, context)
+            elif callback_data == "go_back":
+                await self._handle_go_back(update, context)
+            elif callback_data == "back_to_intro":
+                await self._handle_back_to_intro(update, context)
+            elif callback_data == "back_to_vip_options":
+                await self._handle_back_to_vip_options(update, context)
+            elif callback_data == "exit_confirm":
+                await self._handle_exit_confirm(update, context)
+            elif callback_data == "goodbye":
+                await self._handle_goodbye(update, context)
+            elif callback_data == "continue_exploring":
+                await self._handle_continue_exploring(update, context)
+            elif callback_data == "retry_last_action":
+                await self._handle_retry_last_action(update, context)
             else:
                 await self._handle_unknown_callback(update, context, callback_data)
 
@@ -202,14 +232,33 @@ class CallbackHandler:
             reply_markup = InlineKeyboardMarkup(keyboard)
 
             await update.callback_query.edit_message_text(
-                premium_message, 
-                reply_markup=reply_markup, 
+                premium_message,
+                reply_markup=reply_markup,
                 parse_mode="Markdown"
             )
 
         except Exception as e:
             logger.error(f"❌ Error en _handle_premium: {e}", exc_info=True)
             await self._send_error_message(update)
+
+    async def _handle_get_vip(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Muestra opciones para obtener VIP"""
+
+        message = (
+            "👑 **Acceso VIP**\n\n"
+            "Esta funcionalidad está en desarrollo."
+        )
+
+        keyboard = [
+            [InlineKeyboardButton("⬅️ Volver al Menú", callback_data="back_to_menu")],
+        ]
+        reply_markup = InlineKeyboardMarkup(keyboard)
+
+        await update.callback_query.edit_message_text(
+            message,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
+        )
 
     async def _handle_intro_callbacks(self, update: Update, context: ContextTypes.DEFAULT_TYPE, callback_data: str) -> None:
         """Maneja callbacks de introducción"""
@@ -250,10 +299,212 @@ class CallbackHandler:
         reply_markup = InlineKeyboardMarkup(keyboard)
 
         await update.callback_query.edit_message_text(
-            intro_message, 
-            reply_markup=reply_markup, 
+            intro_message,
+            reply_markup=reply_markup,
             parse_mode="Markdown"
         )
+
+    # === CALLBACKS DE NAVEGACIÓN ===
+
+    async def _handle_back_to_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa al menú principal"""
+
+        first_name = update.effective_user.first_name or "Usuario"
+
+        message = f"""
+🎭 **Menú Principal**
+
+¡{first_name}, has regresado!
+
+Diana me comentó que has estado... observándote.
+
+Tu progreso no ha pasado desapercibido.
+
+¿Qué deseas hacer hoy?
+        """.strip()
+
+        keyboard = [
+            [InlineKeyboardButton("👤 Mi Perfil", callback_data="profile")],
+            [InlineKeyboardButton("🎯 Misiones", callback_data="missions")],
+            [InlineKeyboardButton("🔥 Contenido Premium", callback_data="premium")],
+        ]
+        reply_markup = InlineKeyboardMarkup(keyboard)
+
+        await update.callback_query.edit_message_text(
+            message,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
+        )
+
+    async def _handle_back_to_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa al inicio - mismo que menú principal"""
+        await self._handle_back_to_menu(update, context)
+
+    async def _handle_back_to_profile(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa al perfil"""
+        await self._handle_profile(update, context)
+
+    async def _handle_back_to_missions(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa a misiones"""
+        await self._handle_missions(update, context)
+
+    async def _handle_back_to_premium(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa a premium"""
+        await self._handle_premium(update, context)
+
+    async def _handle_main_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Alias para back_to_menu"""
+        await self._handle_back_to_menu(update, context)
+
+    async def _handle_home(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa al inicio/home"""
+        await self._handle_back_to_menu(update, context)
+
+    async def _handle_cancel(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Cancela operación actual y regresa al menú"""
+
+        message = f"""
+❌ **Operación Cancelada**
+
+{self.lucien.EMOJIS.get('lucien', '🎭')} *[Lucien asiente comprensivamente]*
+
+"*No hay problema. Diana siempre dice que es mejor estar seguro.*"
+
+*[Con aire alentador]*
+
+"*Cuando estés listo, estaremos aquí.*"
+        """.strip()
+
+        keyboard = [
+            [InlineKeyboardButton("🏠 Menú Principal", callback_data="back_to_menu")],
+            [InlineKeyboardButton("🔄 Intentar de Nuevo", callback_data="retry_last_action")],
+        ]
+        reply_markup = InlineKeyboardMarkup(keyboard)
+
+        await update.callback_query.edit_message_text(
+            message,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
+        )
+
+    async def _handle_go_back(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Navegación genérica hacia atrás"""
+        await self._handle_back_to_menu(update, context)
+
+    # NAVEGACIÓN ESPECÍFICA DE SECCIONES
+
+    async def _handle_back_to_intro(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa a las introducciones"""
+
+        first_name = update.effective_user.first_name or "Usuario"
+
+        message = f"""
+✨ **Introducciones**
+
+{self.lucien.EMOJIS.get('lucien', '🎭')} *[Lucien hace una reverencia]*
+
+"*{first_name}, permíteme ofrecerte las presentaciones apropiadas...*"
+
+*[Con aire ceremonioso]*
+
+"*¿A quién te gustaría conocer mejor?*"
+        """.strip()
+
+        keyboard = [
+            [InlineKeyboardButton("✨ Conocer a Diana", callback_data="intro_diana")],
+            [InlineKeyboardButton("🎭 ¿Quién es Lucien?", callback_data="intro_lucien")],
+            [InlineKeyboardButton("🔥 ¿Qué hace este bot especial?", callback_data="intro_bot")],
+            [InlineKeyboardButton("⬅️ Menú Principal", callback_data="back_to_menu")],
+        ]
+        reply_markup = InlineKeyboardMarkup(keyboard)
+
+        await update.callback_query.edit_message_text(
+            message,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
+        )
+
+    async def _handle_back_to_vip_options(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Regresa a opciones VIP"""
+        await self._handle_get_vip(update, context)
+
+    # NAVEGACIÓN CON CONFIRMACIÓN
+
+    async def _handle_exit_confirm(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Confirma si quiere salir"""
+
+        message = f"""
+🚪 **¿Seguro que quieres salir?**
+
+{self.lucien.EMOJIS.get('diana', '👑')} *[Diana aparece con aire melancólico]*
+
+"*¿Ya te vas? Justo cuando las cosas se estaban poniendo... interesantes.*"
+
+*[Con sonrisa traviesa]*
+
+"*Pero entiendo. A veces necesitas... procesar lo que has visto.*"
+
+{self.lucien.EMOJIS.get('lucien', '🎭')} *[Lucien con aire profesional]*
+
+"*Recuerda que siempre puedes regresar con /start*"
+        """.strip()
+
+        keyboard = [
+            [InlineKeyboardButton("🏠 No, quedarme en el menú", callback_data="back_to_menu")],
+            [InlineKeyboardButton("🔄 Continuar explorando", callback_data="continue_exploring")],
+            [InlineKeyboardButton("👋 Sí, salir por ahora", callback_data="goodbye")],
+        ]
+        reply_markup = InlineKeyboardMarkup(keyboard)
+
+        await update.callback_query.edit_message_text(
+            message,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
+        )
+
+    async def _handle_goodbye(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Mensaje de despedida"""
+
+        first_name = update.effective_user.first_name or "Usuario"
+
+        message = f"""
+👋 **Hasta pronto, {first_name}**
+
+{self.lucien.EMOJIS.get('diana', '👑')} *[Diana se despide con elegancia]*
+
+"*Ha sido un placer conocerte, {first_name}. Espero verte pronto...*"
+
+*[Con aire misterioso]*
+
+"*Recuerda: siempre estaré aquí cuando decidas regresar.*"
+
+{self.lucien.EMOJIS.get('lucien', '🎭')} *[Lucien hace una reverencia final]*
+
+"*Que tengas un excelente día. Diana y yo estaremos... esperando.*"
+
+💫 **Para regresar:** Usa /start en cualquier momento
+        """.strip()
+
+        keyboard = [
+            [InlineKeyboardButton("🔄 ¡Espera, no me voy!", callback_data="back_to_menu")],
+        ]
+        reply_markup = InlineKeyboardMarkup(keyboard)
+
+        await update.callback_query.edit_message_text(
+            message,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
+        )
+
+    # === NAVEGACIÓN ADICIONAL ÚTIL ===
+
+    async def _handle_continue_exploring(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Continuar explorando tras confirmación"""
+        await self._handle_back_to_menu(update, context)
+
+    async def _handle_retry_last_action(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Reintenta la última acción"""
+        await self._handle_back_to_menu(update, context)
 
     async def _handle_unknown_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE, callback_data: str) -> None:
         """Maneja callbacks no reconocidos"""


### PR DESCRIPTION
## Summary
- add multiple navigation handlers for callback flow
- route new callbacks in `handle_callback`
- provide stub handler for VIP access

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d74055f08329bd3e916c7b5decef