### PR TITLE
Fix indentation issue in narrative handler

### DIFF
--- a/handlers/callback_handler_narrative.py
+++ b/handlers/callback_handler_narrative.py
@@ -329,9 +329,9 @@ Estaré aquí cuando estés listo para dar ese paso.""",
             "reward_type": "patience_acknowledged"
         }
 
-        def _get_refusal_response(self, first_name: str) -> Dict[str, str]:
+    def _get_refusal_response(self, first_name: str) -> Dict[str, str]:
         """Respuesta cuando el usuario se niega a reaccionar"""
-        
+
         return {
             "diana_message": f"""
 {self.lucien.EMOJIS['diana']} *[Con decepción sutil]*
@@ -345,7 +345,7 @@ Interesante. A veces la resistencia dice más que la obediencia.
 *[Con paciencia enigmática]*
 
 Pero recuerda... algunas puertas solo se abren una vez.""",
-            
+
             "lucien_comment": f"""
 {self.lucien.EMOJIS['lucien']} *[Con sarcasmo palpable]*
 


### PR DESCRIPTION
## Summary
- correct indentation for `_get_refusal_response` in `CallbackHandlerNarrative`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f1e540a483299323e17b646d1cca