### PR TITLE
Integrate MissionService into narrative handler

### DIFF
--- a/handlers/callback_handler_narrative.py
+++ b/handlers/callback_handler_narrative.py
@@ -1,6 +1,7 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 from services.user_service import UserService
+from services.mission_service import MissionService
 from utils.lucien_voice_enhanced import LucienVoiceEnhanced, InteractionPattern, UserArchetype
 import logging
 from typing import Dict, Any
@@ -14,11 +15,23 @@ class CallbackHandlerNarrative:
     def __init__(self):
         try:
             self.user_service = UserService()
+            self.mission_service = MissionService()
             self.lucien = LucienVoiceEnhanced()
             logger.info("✅ CallbackHandlerNarrative inicializado")
         except Exception as e:
             logger.error(f"❌ Error inicializando CallbackHandlerNarrative: {e}")
             raise
+
+    async def start_narrative(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Inicia la narrativa y asigna misiones diarias"""
+
+        user_id = update.effective_user.id
+
+        # Lógica inicial de narrativa (placeholder)
+
+        self.mission_service.create_daily_missions_for_user(user_id)
 
     async def handle_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Router principal con narrativa inmersiva"""

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -120,6 +120,11 @@ class MissionService:
 
         return created_missions
 
+    def create_daily_missions_for_user(self, user_id: int) -> List[Mission]:
+        """Alias para asignar misiones diarias a un usuario"""
+
+        return self.assign_daily_missions(user_id)
+
     def generate_personalized_missions(self, user_id: int) -> List[Dict[str, Any]]:
         """Genera misiones personalizadas para el usuario (dummy)."""
 


### PR DESCRIPTION
## Summary
- hook `MissionService` into `CallbackHandlerNarrative`
- provide a method to start the narrative that assigns daily missions
- expose helper `create_daily_missions_for_user` in `MissionService`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68668b9712288329bba4f7e07da41bc4