### PR TITLE
Add admin-aware menu and new admin commands

### DIFF
--- a/handlers/callback_handler_narrative.py
+++ b/handlers/callback_handler_narrative.py
@@ -2,6 +2,7 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 from services.user_service import UserService
 from services.mission_service import MissionService
+from services.admin_service import AdminService
 from utils.lucien_voice_enhanced import LucienVoiceEnhanced, InteractionPattern, UserArchetype
 import logging
 from typing import Dict, Any
@@ -16,6 +17,7 @@ class CallbackHandlerNarrative:
         try:
             self.user_service = UserService()
             self.mission_service = MissionService()
+            self.admin_service = AdminService()
             self.lucien = LucienVoiceEnhanced()
             logger.info("✅ CallbackHandlerNarrative inicializado")
         except Exception as e:
@@ -506,17 +508,43 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
     # === MENÚS PRINCIPALES CON NARRATIVA ===
 
     async def _show_main_menu_narrative(self, update: Update, context: ContextTypes.DEFAULT_TYPE, user: Any, narrative_state: Any) -> None:
-        """Menú principal con contexto narrativo"""
-        
+        """Menú principal con detección de administradores"""
+
         try:
             first_name = getattr(user, 'first_name', 'Usuario')
-            
+            user_telegram_id = update.effective_user.id
+
+            # Verificar si es administrador
+            is_admin = self.admin_service.is_admin(user_telegram_id)
+            admin_level = None
+
+            if is_admin:
+                admin = self.admin_service.get_admin(user_telegram_id)
+                admin_level = admin.admin_level.value if admin else None
+
             # Detectar progreso narrativo actual
             current_level = getattr(narrative_state, 'current_level', 'newcomer')
-            
-            # Mensaje adaptativo según progreso
-            if current_level == 'newcomer':
+
+            # Mensaje adaptativo según admin/usuario
+            if is_admin:
                 menu_message = f"""
+{self.lucien.EMOJIS['lucien']} *[Con reverencia especial]*
+
+"*{first_name}... mi estimado administrador.*"
+
+👑 **Panel Principal - Administrador {admin_level.title()}**
+
+*[Con aire conspirativo]*
+
+Diana me ha informado de tu... autoridad especial. 
+
+*[Con respeto profesional]*
+
+¿Deseas gestionar el reino o disfrutar como usuario?
+                """.strip()
+            else:
+                if current_level == 'newcomer':
+                    menu_message = f"""
 {self.lucien.EMOJIS['lucien']} *[Con aire de recepcionista sarcástico]*
 
 "*Oh, {first_name}... de vuelta al lobby. Qué... predecible.*"
@@ -526,9 +554,9 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
 Diana está observando tu... progreso. O la falta de él.
 
 ¿Qué intentarás ahora?
-                """.strip()
-            else:
-                menu_message = f"""
+                    """.strip()
+                else:
+                    menu_message = f"""
 {self.lucien.EMOJIS['lucien']} *[Con reconocimiento reluctante]*
 
 "*{first_name}... has progresado más de lo que esperaba.*"
@@ -538,21 +566,37 @@ Diana está observando tu... progreso. O la falta de él.
 Diana ha estado... comentando sobre ti. Eso es... unusual.
 
 ¿Continuamos con tu desarrollo personal?
-                """.strip()
+                    """.strip()
 
-            # Botones adaptativos según progreso
-            keyboard = [
-                [InlineKeyboardButton("👤 Mi Progreso Narrativo", callback_data="narrative_progress")],
+            # Botones adaptativos según admin/usuario
+            keyboard = []
+
+            if is_admin:
+                keyboard.extend([
+                    [InlineKeyboardButton("👑 Panel de Administración", callback_data="admin_panel")],
+                    [InlineKeyboardButton("🎫 Generar Token VIP", callback_data="generate_vip_token")],
+                    [InlineKeyboardButton("📊 Ver Analytics", callback_data="admin_analytics")],
+                    [InlineKeyboardButton("━━━━━━━━━━━━━━━━━━━━", callback_data="separator")]
+                ])
+
+            keyboard.extend([
+                [InlineKeyboardButton("👤 Mi Perfil", callback_data="profile")],
                 [InlineKeyboardButton("🎭 Continuar Historia", callback_data="continue_story")],
-                [InlineKeyboardButton("🗺️ Revisar Pistas", callback_data="review_clues")],
-                [InlineKeyboardButton("💬 Hablar con Diana", callback_data="talk_to_diana")],
-                [InlineKeyboardButton("⚙️ Configuración", callback_data="settings")],
-            ]
+                [InlineKeyboardButton("🎯 Mis Misiones", callback_data="missions")],
+            ])
+
+            if hasattr(narrative_state, 'has_divan_access') and narrative_state.has_divan_access:
+                keyboard.append([InlineKeyboardButton("💎 Acceso al Diván", callback_data="divan_access")])
+            else:
+                keyboard.append([InlineKeyboardButton("🔥 Contenido Premium", callback_data="premium")])
+
+            keyboard.append([InlineKeyboardButton("⚙️ Configuración", callback_data="settings")])
+
             reply_markup = InlineKeyboardMarkup(keyboard)
 
             await update.callback_query.edit_message_text(
-                menu_message, 
-                reply_markup=reply_markup, 
+                menu_message,
+                reply_markup=reply_markup,
                 parse_mode="Markdown"
             )
 

--- a/handlers/command_handlers.py
+++ b/handlers/command_handlers.py
@@ -1,6 +1,8 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 from services.user_service import UserService
+from services.admin_service import AdminService
+from models.admin import AdminLevel
 from utils.lucien_voice import LucienVoice
 import logging
 from typing import Dict, Any
@@ -13,6 +15,7 @@ class CommandHandlers:
     def __init__(self):
         try:
             self.user_service = UserService()
+            self.admin_service = AdminService()
             self.lucien = LucienVoice()
             logger.info("✅ CommandHandlers inicializado")
         except Exception as e:
@@ -405,3 +408,126 @@ Diana {self._get_diana_opinion(trust_level)}
         except Exception as e:
             logger.error(f"❌ Error en admin_command: {e}", exc_info=True)
             await self._send_error_message(update, "Error mostrando panel de administrador")
+
+    async def create_first_admin_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Comando especial para crear el primer super admin - Solo funciona una vez"""
+
+        try:
+            admin_service = AdminService()
+            user_telegram_id = update.effective_user.id
+
+            # Verificar si ya existen administradores
+            all_admins = admin_service.get_all_admins(include_inactive=True)
+            if all_admins:
+                await update.message.reply_text(
+                    f"🛡️ *Sistema de Administración*\n\n"
+                    f"Ya existen administradores en el sistema.\n\n"
+                    f"Si necesitas acceso de administrador, contacta a un Super Admin existente.",
+                    parse_mode="Markdown"
+                )
+                return
+
+            # Crear primer super admin
+            user_data = {
+                "username": update.effective_user.username,
+                "first_name": update.effective_user.first_name,
+                "last_name": update.effective_user.last_name,
+            }
+
+            result = admin_service.create_admin(
+                telegram_id=user_telegram_id,
+                admin_level=AdminLevel.SUPER_ADMIN,
+                created_by_telegram_id=user_telegram_id,
+                user_data=user_data
+            )
+
+            if result.get("success"):
+                welcome_message = f"""
+👑 **¡Bienvenido Super Administrador!**
+
+{self.lucien.EMOJIS['lucien']} *[Con máximo respeto]*
+
+"*{update.effective_user.first_name}, Diana me ha informado de su nombramiento como Super Administrador.*"
+
+*[Con aire ceremonioso]*
+
+"*Usted ahora tiene control total sobre el sistema. Use este poder... sabiamente.*"
+
+**Sus permisos incluyen:**
+• 🎫 Generar tokens VIP ilimitados
+• 📺 Gestionar todos los canales
+• 👥 Administrar usuarios
+• 👑 Crear y gestionar otros administradores
+• 📊 Acceso completo a analytics
+• ⚙️ Configurar el sistema
+
+**Comandos importantes:**
+• `/admin_panel` - Panel de administración
+• `/create_admin` - Crear nuevos administradores
+• `/system_status` - Estado del sistema
+
+*[Con advertencia profesional]*
+
+"*Recuerde que Diana observa incluso a sus administradores...*"
+                """.strip()
+
+                await update.message.reply_text(welcome_message, parse_mode="Markdown")
+
+                admin_service.log_admin_action(
+                    admin_telegram_id=user_telegram_id,
+                    action_type="first_admin_created",
+                    action_description="Primer Super Admin creado en el sistema",
+                    action_data=f'{{"first_admin_id": {result["admin"].id}, "telegram_id": {user_telegram_id}}}'
+                )
+
+            else:
+                await update.message.reply_text(
+                    f"❌ Error creando administrador: {result.get('error', 'Error desconocido')}"
+                )
+
+        except Exception as e:
+            logger.error(f"❌ Error en create_first_admin_command: {e}", exc_info=True)
+            await self._send_error_message(update, "Error creando primer administrador")
+
+    async def admin_panel_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Comando /admin_panel - Acceso directo al panel de administración"""
+
+        try:
+            admin_service = AdminService()
+            user_telegram_id = update.effective_user.id
+
+            if not admin_service.is_admin(user_telegram_id):
+                await update.message.reply_text(
+                    f"🚫 **Acceso Denegado**\n\n"
+                    f"Este comando es solo para administradores.",
+                    parse_mode="Markdown"
+                )
+                return
+
+            admin = admin_service.get_admin(user_telegram_id)
+
+            quick_admin_message = f"""
+👑 **Panel de Administración**
+
+Hola {update.effective_user.first_name}!
+
+**Tu nivel:** {admin.admin_level.value.title()}
+**Estado:** {'✅ Activo' if admin.is_active else '❌ Inactivo'}
+
+**Accesos rápidos:**
+• Para generar token VIP: Usar botones del bot principal
+• Para gestionar canales: Acceder via menú del bot
+• Para ver analytics: Panel principal del bot
+
+💡 **Consejo:** Usa el bot principal para acceder a todas las funciones de administración con interfaz completa.
+            """.strip()
+
+            await update.message.reply_text(quick_admin_message, parse_mode="Markdown")
+
+        except Exception as e:
+            logger.error(f"❌ Error en admin_panel_command: {e}", exc_info=True)
+            await update.message.reply_text("❌ Error accediendo al panel de administración.")

--- a/main.py
+++ b/main.py
@@ -104,6 +104,12 @@ class DianaBot:
             CommandHandler("profile", command_handlers.profile_command)
         )
         self.application.add_handler(
+            CommandHandler("create_first_admin", command_handlers.create_first_admin_command)
+        )
+        self.application.add_handler(
+            CommandHandler("admin_panel", command_handlers.admin_panel_command)
+        )
+        self.application.add_handler(
             CommandHandler("generate_vip_token", generate_vip_token)
         )
         self.application.add_handler(


### PR DESCRIPTION
## Summary
- detect admin level in the narrative main menu
- add quick admin options when viewing the main menu
- add commands to create the first super admin and to open the admin panel
- register new commands in the application

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686697e57890832980b265cce6c2dada