### PR TITLE
Implement admin creation commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,6 +104,12 @@ class DianaBot:
             CommandHandler("profile", command_handlers.profile_command)
         )
         self.application.add_handler(
+            CommandHandler("create_first_admin", command_handlers.create_first_admin_command)
+        )
+        self.application.add_handler(
+            CommandHandler("admin_panel", command_handlers.admin_panel_command)
+        )
+        self.application.add_handler(
             CommandHandler("generate_vip_token", generate_vip_token)
         )
         self.application.add_handler(


### PR DESCRIPTION
## Summary
- add AdminService and AdminLevel imports
- implement `/create_first_admin` and `/admin_panel` commands
- wire up new commands in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669e09900c8329adea1e0f09354b4f