### PR TITLE
Fix indentation in User model methods

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -44,31 +44,28 @@ class User(Base):
     missions = relationship("UserMission", back_populates="user")
     lore_pieces = relationship("UserLorePiece", back_populates="user")
     auction_bids = relationship("AuctionBid", back_populates="user")
-    narrative_state = relationship("UserNarrativeState", uselist=False, back_populates="user")
-
-  
+    narrative_state = relationship(
+        "UserNarrativeState",
+        uselist=False,
+        back_populates="user",
+    )
 
     def days_left(self) -> int:
+        """Retorna los días restantes de membresía VIP."""
 
-    """Retorna los días restantes de membresía VIP."""
+        if not self.vip_expires:
+            return 0
 
-    if not self.vip_expires:
+        return max(0, (self.vip_expires - datetime.utcnow()).days)
 
-        return 0
+    def vip_expires_soon(self, days: int = 3) -> bool:
+        """Indica si el VIP expira en los próximos ``days`` días."""
 
-    return max(0, (self.vip_expires - datetime.utcnow()).days)
+        if not self.is_vip or not self.vip_expires:
+            return False
 
-def vip_expires_soon(self, days: int = 3) -> bool:
-
-    """Indica si el VIP expira en los próximos ``days`` días."""
-
-    if not self.is_vip or not self.vip_expires:
-
-        return False
-
-    remaining = (self.vip_expires - datetime.utcnow()).days
-
-    return 0 < remaining <= days
+        remaining = (self.vip_expires - datetime.utcnow()).days
+        return 0 < remaining <= days
 
 class UserStats(Base):
     __tablename__ = "user_stats"


### PR DESCRIPTION
## Summary
- indent `days_left` and `vip_expires_soon` methods inside `User`
- reformat `narrative_state` relationship definition

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m py_compile models/user.py`


------
https://chatgpt.com/codex/tasks/task_e_6866cf679f388329850edb9504c84d53