### PR TITLE
Implement admin callbacks

### DIFF
--- a/services/channel_service.py
+++ b/services/channel_service.py
@@ -1022,6 +1022,21 @@ Bienvenido al círculo íntimo. Diana está... complacida.
             print(f"Error getting active channels count: {e}")
             return 0
 
+    async def get_pending_requests_count(self) -> int:
+        """Cuenta solicitudes pendientes de canales"""
+        try:
+            from sqlalchemy import func
+
+            result = (
+                self.db.query(func.count(Channel.id))
+                .filter(Channel.is_active == False)
+                .scalar()
+            )
+            return result or 0
+        except Exception as e:
+            print(f"Error getting pending requests count: {e}")
+            return 0
+
     async def _schedule_auto_approval(self, channel_id: int, delay_hours: int = 24):
         """Programa aprobación automática de canal"""
         try:

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -636,6 +636,24 @@ class UserService:
             print(f"Error getting advanced users count: {e}")
             return 0
 
+    async def get_vip_users_count(self) -> int:
+        """Cuenta usuarios VIP activos"""
+        try:
+            from datetime import datetime
+
+            return (
+                self.db.query(func.count(User.id))
+                .filter(
+                    (User.is_vip == True)
+                    & ((User.vip_expires.is_(None)) | (User.vip_expires > datetime.now()))
+                )
+                .scalar()
+                or 0
+            )
+        except Exception as e:
+            print(f"Error getting VIP users count: {e}")
+            return 0
+
     async def get_users_paginated(self, page: int = 0, per_page: int = 10):
         """Obtiene usuarios paginados"""
         try:
@@ -1123,6 +1141,24 @@ En todos mis años como su mayordomo, he visto a muy pocos llegar a este nivel d
             return result or 0
         except Exception as e:
             print(f"Error getting advanced users count: {e}")
+            return 0
+
+    async def get_vip_users_count(self) -> int:
+        """Cuenta usuarios VIP activos"""
+        try:
+            from datetime import datetime
+
+            result = (
+                self.db.query(func.count(User.id))
+                .filter(
+                    (User.is_vip == True)
+                    & ((User.vip_expires.is_(None)) | (User.vip_expires > datetime.now()))
+                )
+                .scalar()
+            )
+            return result or 0
+        except Exception as e:
+            print(f"Error getting VIP users count: {e}")
             return 0
 
     async def get_users_paginated(self, page: int = 0, per_page: int = 10):


### PR DESCRIPTION
## Summary
- implement admin management callbacks for channels, missions, games and stats
- add routing for new callbacks in handler
- add pending request count to `ChannelService`
- add VIP users count to `UserService`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e8cd657c83299db98b5829f88702