### PR TITLE
Implement callbacks for trivia/math answers and backpack view

### DIFF
--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1284,4 +1284,16 @@ En todos mis años como su mayordomo, he visto a muy pocos llegar a este nivel d
         except Exception as e:
             print(f"Error getting user ranking position: {e}")
             return 0
+
+    async def update_user(self, user):
+        """Actualiza datos del usuario en la base de datos"""
+        try:
+            self.db.add(user)
+            self.db.commit()
+            self.db.refresh(user)
+            return True
+        except Exception as e:
+            print(f"Error updating user: {e}")
+            self.db.rollback()
+            return False
    


### PR DESCRIPTION
## Summary
- add handlers for trivia answers and math answers
- add backpack clue and progress callbacks
- detect callback patterns and add routing table entries
- implement level up helper method
- add `update_user` method in user service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f010e1908329801cbcafe4ac8156