### PR TITLE
Fix user service sync usage

### DIFF
--- a/handlers/callback_handler_narrative.py
+++ b/handlers/callback_handler_narrative.py
@@ -2670,7 +2670,7 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
     async def _check_level_up(self, user) -> bool:
         """Verifica y procesa subida de nivel"""
         try:
-            required_xp = await self.user_service.calculate_xp_for_level(user.level + 1)
+            required_xp = self.user_service.calculate_xp_for_level(user.level + 1)
 
             if user.experience >= required_xp:
                 user.level += 1
@@ -2713,11 +2713,12 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
                 main_menu_text, keyboard = self._build_static_menu(user, user_role)
 
             # Verificar si es admin para añadir acceso al Diván
+            is_admin = False
             try:
-                admin = self.admin_service.get_admin_by_user_id(user_id)
+                admin = await self.admin_service.get_admin_by_user_id(user_id)
                 is_admin = admin and admin.is_active
             except Exception:
-                is_admin = False
+                pass
 
             if is_admin:
                 keyboard.append([InlineKeyboardButton("🏛️ Panel de Administración", callback_data="divan_access")])
@@ -2853,7 +2854,7 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
                 await self._send_error_message(update, context, "Usuario no encontrado")
                 return
 
-            next_level_xp = await self.user_service.calculate_xp_for_level(user.level + 1)
+            next_level_xp = self.user_service.calculate_xp_for_level(user.level + 1)
             progress_percentage = (
                 (user.experience / next_level_xp) * 100 if next_level_xp > 0 else 100
             )
@@ -3028,8 +3029,16 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
                 await self._send_error_message(update, context, "Usuario no encontrado")
                 return
 
-            active_missions = await self.mission_service.get_user_active_missions(user_id)
-            completed_count = await self.mission_service.get_user_completed_missions_count(user_id)
+            active_missions = (
+                self.mission_service.get_user_active_missions(user_id)
+                if hasattr(self.mission_service, "get_user_active_missions")
+                else []
+            )
+            completed_count = (
+                self.mission_service.get_user_completed_missions_count(user_id)
+                if hasattr(self.mission_service, "get_user_completed_missions_count")
+                else 0
+            )
 
             missions_text = "🎯 *Tus Misiones*\n\n"
             missions_text += "📊 **Progreso:**\n"
@@ -3132,7 +3141,7 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
                 await self._send_error_message(update, context, "Usuario no encontrado")
                 return
 
-            lore_pieces = await self.user_service.get_user_lore_pieces(user_id)
+            lore_pieces = self.user_service.get_user_lore_pieces(user_id)
 
             keyboard = [
                 [InlineKeyboardButton("🔍 Ver Pistas", callback_data="backpack_view_clues")],
@@ -3168,7 +3177,7 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
 
         try:
             user = self.user_service.get_user_by_telegram_id(user_id)
-            lore_pieces = await self.user_service.get_user_lore_pieces(user_id)
+            lore_pieces = self.user_service.get_user_lore_pieces(user_id)
 
             if not lore_pieces:
                 clues_text = (
@@ -3212,7 +3221,7 @@ Pero recuerda... algunas puertas solo se abren una vez.""",
 
         try:
             user = self.user_service.get_user_by_telegram_id(user_id)
-            lore_pieces = await self.user_service.get_user_lore_pieces(user_id)
+            lore_pieces = self.user_service.get_user_lore_pieces(user_id)
 
             progress_text = (
                 f"📈 *Tu Progreso Narrativo*\n\n"

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -130,8 +130,8 @@ class MissionService:
 
         return self.assign_daily_missions(user_id)
 
-    async def get_user_active_missions(self, telegram_id: int) -> List[dict]:
-        """Devuelve misiones activas del usuario"""
+    def get_user_active_missions(self, telegram_id: int) -> List[dict]:
+        """Devuelve misiones activas del usuario - SÍNCRONO"""
         try:
             user = (
                 self.db.query(User)
@@ -157,8 +157,8 @@ class MissionService:
             print(f"Error getting user active missions: {e}")
             return []
 
-    async def get_user_completed_missions_count(self, telegram_id: int) -> int:
-        """Cuenta misiones completadas del usuario"""
+    def get_user_completed_missions_count(self, telegram_id: int) -> int:
+        """Cuenta misiones completadas del usuario - SÍNCRONO"""
         try:
             user = (
                 self.db.query(User)

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -8,10 +8,11 @@ from models.narrative_state import (
     EmotionalResponse,
 )
 from models.mission import Mission
-from config.database import get_db
+from config.database import get_db, SessionLocal
 from utils.lucien_voice import LucienVoice
 from typing import Dict, Any, List, Optional, Tuple
 from datetime import datetime, timedelta
+from contextlib import contextmanager
 import random
 
 
@@ -21,6 +22,15 @@ class UserService:
     def __init__(self):
         self.db = next(get_db())
         self.lucien = LucienVoice()
+
+    @contextmanager
+    def get_db_session(self):
+        """Provide a transactional scope around a series of operations."""
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
 
     def get_or_create_user(
         self,
@@ -1184,8 +1194,8 @@ En todos mis años como su mayordomo, he visto a muy pocos llegar a este nivel d
             print(f"Error getting paginated users: {e}")
             return []
 
-    async def calculate_xp_for_level(self, target_level: int) -> int:
-        """Calcula XP necesaria para un nivel específico"""
+    def calculate_xp_for_level(self, target_level: int) -> int:
+        """Calcula XP necesaria para un nivel específico - SÍNCRONO"""
         return (target_level ** 2) * 100 + target_level * 50
 
     def calculate_daily_gift(self, user_id: int) -> dict:
@@ -1237,8 +1247,8 @@ En todos mis años como su mayordomo, he visto a muy pocos llegar a este nivel d
             print(f"Error giving daily gift: {e}")
             return False
 
-    async def get_user_lore_pieces(self, user_id: int):
-        """Obtiene piezas de historia del usuario"""
+    def get_user_lore_pieces(self, user_id: int):
+        """Obtiene piezas de historia del usuario - SÍNCRONO"""
         try:
             return []
         except Exception as e:


### PR DESCRIPTION
## Summary
- add contextmanaged get_db_session in user service
- convert `calculate_xp_for_level` and `get_user_lore_pieces` to synchronous methods
- make mission service mission retrieval synchronous
- update narrative callbacks to use synchronous methods and await admin checks

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867073bced88329a9b6a047ade9e1cb